### PR TITLE
Change layout of event edit page like google calender

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,6 @@ gem "awesome_nested_set"
 # For generation API document automatically
 gem "autodoc", group: :test
 gem "factory_girl_rails", group: :test
+
+# Knockoutjs
+gem "knockoutjs-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     jquery-ui-rails (5.0.3)
       railties (>= 3.2.16)
     json (1.8.1)
+    knockoutjs-rails (3.3.0.1)
+      railties (>= 3.1, < 5)
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.6.0)
@@ -179,6 +181,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-rails
+  knockoutjs-rails
   less-rails
   nokogiri
   rails (= 4.1.8)
@@ -191,3 +194,6 @@ DEPENDENCIES
   turbolinks
   twitter-bootstrap-rails
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,3 +21,4 @@
 //= require_tree .
 //= require jquery-ui
 //= require bootstrap-table
+//= require knockout

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -162,5 +162,31 @@ ready = ->
 
   $('#myTab a:last').tab('show')
 
+  vm =
+    optionValues: [
+      "Weekly"
+      "Monthly"
+      "Yearly"
+    ]
+    optionNum: [1..30]
+    selectedOptionValue : ko.observable("Weekly")
+    repeatChecked : ko.observable(false)
+
+  vm.repeatByWeek = ko.computed((->
+    vm.selectedOptionValue() == "Weekly"
+  ), vm)
+  vm.repeatByMonth = ko.computed((->
+    vm.selectedOptionValue() == "Monthly"
+  ), vm)
+  vm.repeatByYear = ko.computed((->
+    vm.selectedOptionValue() == "Yearly"
+  ), vm)
+  ko.computed((->
+    if vm.repeatChecked()
+      $('#repeatSettings').modal()
+  ), vm)
+
+  ko.applyBindings vm
+
 $(document).ready(ready)
 $(document).on('page:load', ready)

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -160,6 +160,18 @@ ready = ->
       previous: "fa fa-chevron-left"
       next: "fa fa-chevron-right"
 
+  $('#eventStartDate').datetimepicker
+    format: "YYYY/MM/DD"
+    icons:
+      previous: "fa fa-chevron-left"
+      next: "fa fa-chevron-right"
+
+  $('#eventEndDate').datetimepicker
+    format: "YYYY/MM/DD"
+    icons:
+      previous: "fa fa-chevron-left"
+      next: "fa fa-chevron-right"
+
   $('#myTab a:last').tab('show')
 
   vm =
@@ -171,6 +183,7 @@ ready = ->
     optionNum: [1..30]
     selectedOptionValue : ko.observable("Weekly")
     repeatChecked : ko.observable(false)
+    allDayChecked : ko.observable(false)
 
   vm.repeatByWeek = ko.computed((->
     vm.selectedOptionValue() == "Weekly"
@@ -185,6 +198,9 @@ ready = ->
     if vm.repeatChecked()
       $('#repeatSettings').modal()
   ), vm)
+  vm.notAllDayChecked = ko.computed((->
+    !vm.allDayChecked()
+  ),vm)
 
   ko.applyBindings vm
 

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -17,7 +17,23 @@
   display: none;
 }
 
+.weekly{
+}
+
+.monthly{
+  display: none;
+}
+
+.yearly{
+  display: none;
+}
+
 .form-th {
   padding: 0px 15px 0px 0px;
   text-align: right;
+}
+
+.modal-repeat {
+  width:450px;
+  margin-left: 75px;
 }

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -16,3 +16,8 @@
   float: left;
   display: none;
 }
+
+.form-th {
+  padding: 0px 15px 0px 0px;
+  text-align: right;
+}

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -63,6 +63,112 @@
       </div>
     </div>
   </div>
+
+  <div class="modal fade" id="repeatSettings" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content modal-repeat">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title"><b>Repeat</b></h4>
+        </div>
+        <div class="modal-body">
+          <table align="center">
+            <tbody>
+              <tr>
+                <th class="form-th">
+                  Repeats:
+                </th>
+                <td>
+                  <select data-bind="options: optionValues, value: selectedOptionValue" class="repeat-type"></select>
+                </td>
+              </tr>
+              <tr data-bind="visible: repeatByWeek">
+                <th class="form-th">
+                  Repeat every:
+                </th>
+                <td>
+                  <select data-bind="options: optionNum"></select>
+                  weeks
+                </td>
+              </tr>
+              <tr data-bind="visible: repeatByWeek">
+                <th class="form-th">
+                  Repeat on:
+                </th>
+                <td>
+                  <input type="checkbox" name="wday" value="1">S
+                  <input type="checkbox" name="wday" value="2">M
+                  <input type="checkbox" name="wday" value="3">T
+                  <input type="checkbox" name="wday" value="4">W
+                  <input type="checkbox" name="wday" value="5">T
+                  <input type="checkbox" name="wday" value="6">F
+                  <input type="checkbox" name="wday" value="7">S
+                </td>
+              </tr><!-- /.weekly -->
+              <tr data-bind="visible: repeatByMonth">
+                <th class="form-th">
+                  Repeat every:
+                </th>
+                <td>
+                  <select data-bind="options: optionNum"></select>
+                  months
+                </td>
+              </tr>
+              <tr data-bind="visible: repeatByMonth">
+                <th class="form-th">
+                  Repeat by:
+                </th>
+                <td>
+                  <input type="radio" name="repeat_by_month" value="by_month" checked>day of the month
+                  <input type="radio" name="repeat_by_week" value="by_week">day of the week
+                </td>
+              </tr><!-- /.monthly -->
+              <tr data-bind="visible: repeatByYear">
+                <th class="form-th">
+                  Repeat every:
+                </th>
+                <td>
+                  <select data-bind="options: optionNum"></select>
+                  years
+                </td>
+              </tr><!-- /.yearly -->
+              <tr>
+                <th class="form-th">
+                  Starts on:
+                </th>
+                <td>
+                  <input type="text" value="Select date" disabled="disabled" />
+                </td>
+              </tr>
+              <tr>
+                <th valign="top" class="form-th">
+                  Ends:
+                </th>
+                <td>
+                  <input type="radio" name="never" checked> Never <br>
+                  <input type="radio" name="times"> After <input type="text" size="5" name="tims_input" value="15"> occurrences <br>
+                  <input type="radio" name="until"> On <input type="date" name="until_input">
+                </td>
+              </tr>
+              <tr>
+                <th class="form-th">
+                  Summary:
+                </th>
+                <td>
+                  Summary
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div><!-- /.modal-body -->
+        <div class="modal-footer center">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
+          <button type="button" class="btn btn-default"  data-dismiss="modal">Cancel</button>
+        </div><!-- /.modal-footer -->
+      </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+  </div><!-- /.modal -->
+
   <%= f.hidden_field :categories %>
   <%= f.hidden_field :status %>
   <%= f.hidden_field :recurrence_id, :value => "Inbox" %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -11,34 +11,57 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :description %><br>
-    <%= f.text_area :description %>
-  </div>
-  <div class="field">
-    <%= f.label :location %><br>
-    <%= f.text_area :location %>
-  </div>
-  <div class="field">
-    <%= f.label :summary %><br>
-    <%= f.text_area :summary %>
-  </div>
-  <div class="field">
-    <%= f.label :dtstart %><br>
-    <%= f.datetime_select :dtstart %>
-  </div>
-  <div class="field">
-    <%= f.label :dtend %><br>
-    <%= f.datetime_select :dtend %>
-  </div>
-  </div>
-  <div class="field">
-  </div>
-  </div>
-  </div>
-  </div>
   <div class="actions">
-    <%= f.submit %>
+    <%= link_to :back, {:class=>"btn btn-default"} do %>
+      <i class="fa fa-arrow-left"></i>
+    <% end %>
+    <%= f.submit "SAVE", class:"btn btn-danger" %>
+    <%= link_to 'Discard', events_path, {:class=>"btn btn-default"} %>
+  </div>
+  <hr>
+  <div class="field">
+    <%= f.text_field :summary, :placeholder => "Untitled event" %>
+  </div>
+  <div class="field input-group">
+    <%= f.text_field :dtstart, id:"eventStartTime" %>  to  <%= f.text_field :dtend, id:"eventEndTime" %>
+  </div>
+  <div>
+    <input type="checkbox" data-bind="checked: allDayChecked"> All day
+    <input type="checkbox" data-bind="checked: repeatChecked"> Repeat...
+  </div>
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active" role="presentation">
+      <a aria-controls="detail" data-toggle="tab" href="#detail" id="detail-tab" role="tab">Event details</a>
+    </li>
+  </ul>
+
+  <div class="field form-group">
+    <div class="tab-content">
+      <div class="tab-pane active" id="detail" role="tabpanel">
+        <div class="field">
+          <table>
+            <tbody>
+              <tr>
+                <th class="form-th">
+                  <%= f.label :Where %>
+                </th>
+                <td>
+                  <%= f.text_field :location, :placeholder => "Enter a location" %>
+                </td>
+              </tr>
+              <tr>
+                <th valign="top" class="form-th">
+                  <%= f.label :description %>
+                </th>
+                <td>
+                  <%= f.text_area :description %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
   <%= f.hidden_field :categories %>
   <%= f.hidden_field :status %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -22,8 +22,11 @@
   <div class="field">
     <%= f.text_field :summary, :placeholder => "Untitled event" %>
   </div>
-  <div class="field input-group">
+  <div class="field input-group" data-bind="visible: notAllDayChecked">
     <%= f.text_field :dtstart, id:"eventStartTime" %>  to  <%= f.text_field :dtend, id:"eventEndTime" %>
+  </div>
+  <div class="field input-group" data-bind="visible: allDayChecked">
+    <%= f.text_field :dtstart, id:"eventStartDate" %>  to  <%= f.text_field :dtend, id:"eventEndDate" %>
   </div>
   <div>
     <input type="checkbox" data-bind="checked: allDayChecked"> All day

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -12,24 +12,12 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :uid %><br>
-    <%= f.text_area :uid %>
-  </div>
-  <div class="field">
-    <%= f.label :categories %><br>
-    <%= f.text_area :categories %>
-  </div>
-  <div class="field">
     <%= f.label :description %><br>
     <%= f.text_area :description %>
   </div>
   <div class="field">
     <%= f.label :location %><br>
     <%= f.text_area :location %>
-  </div>
-  <div class="field">
-    <%= f.label :status %><br>
-    <%= f.text_area :status %>
   </div>
   <div class="field">
     <%= f.label :summary %><br>
@@ -43,39 +31,21 @@
     <%= f.label :dtend %><br>
     <%= f.datetime_select :dtend %>
   </div>
-  <div class="field">
-    <%= f.label :recurrence_id %><br>
-    <%= f.number_field :recurrence_id %>
   </div>
   <div class="field">
-    <%= f.label :related_to %><br>
-    <%= f.text_area :related_to %>
   </div>
-  <div class="field">
-    <%= f.label :exdate %><br>
-    <%= f.datetime_select :exdate %>
   </div>
-  <div class="field">
-    <%= f.label :rdate %><br>
-    <%= f.datetime_select :rdate %>
   </div>
-  <div class="field">
-    <%= f.label :created %><br>
-    <%= f.datetime_select :created %>
-  </div>
-  <div class="field">
-    <%= f.label :last_modified %><br>
-    <%= f.datetime_select :last_modified %>
-  </div>
-  <div class="field">
-    <%= f.label :sequence %><br>
-    <%= f.datetime_select :sequence %>
-  </div>
-  <div class="field">
-    <%= f.label :rrule %><br>
-    <%= f.text_field :rrule %>
   </div>
   <div class="actions">
     <%= f.submit %>
   </div>
+  <%= f.hidden_field :categories %>
+  <%= f.hidden_field :status %>
+  <%= f.hidden_field :recurrence_id, :value => "Inbox" %>
+  <%= f.hidden_field :related_to %>
+  <%= f.hidden_field :uid %>
+  <%= f.hidden_field :created %>
+  <%= f.hidden_field :last_modified %>
+  <%= f.hidden_field :sequence %>
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,4 +1,5 @@
 <h1>Editing event</h1>
+<%= javascript_include_tag "events" %>
 
 <%= render 'form' %>
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,7 +1,3 @@
-<h1>Editing event</h1>
 <%= javascript_include_tag "events" %>
 
 <%= render 'form' %>
-
-<%= link_to 'Show', @event %> |
-<%= link_to 'Back', events_path %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,6 +1,3 @@
-<h1>New event</h1>
 <%= javascript_include_tag "events" %>
 
 <%= render 'form' %>
-
-<%= link_to 'Back', events_path %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,4 +1,5 @@
 <h1>New event</h1>
+<%= javascript_include_tag "events" %>
 
 <%= render 'form' %>
 


### PR DESCRIPTION
予定編集画面に以下の変更を加えた．
+ ユーザが入力しない項目を非表示に変更
+ 見た目をGoogleカレンダーのように変更
+ 実施日時の設定にdatetimepickerを使用
+ 繰り返しを設定するためのmodalを作成

また，以下の問題が残っている．
+ 見た目を変更しただけであるため，登録は行えない
  + railsのEventのcolumnと対応付ける必要がある

| Event column | edit form |
| --- | --- |
| uid(text) | no input |
| categories(text) | no input |
| description(text) | description(text) |
| location(text) | where(text) |
| status(text) | no input |
| summary(text) | summary(text) |
| dtstart(datetime) | dtstart(text) |
| dtend(datetime) | dtend(text) |
| recurrence_id(integer) | no input(text) |
| related_to(text) | no input |
| exdate(datetime) | × |
| rdate(datetime) | × |
| created(datetime) | no input |
| last_modified(datetime) | no input |
| sequence(datetime) | no input |
| rrule(string) | × |
| created_at(datetime) | × |
| updated_at(datetime) | × |
| calendar_id(integer) | × |
| × | All day |

+ 繰り返しのSUMMARYの生成ができていない
  + 入力された規則を解析する必要がある