### PR TITLE
Change layout of event create modal like google calender

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -183,7 +183,7 @@ ready = ->
     optionNum: [1..30]
     selectedOptionValue : ko.observable("Weekly")
     repeatChecked : ko.observable(false)
-    allDayChecked : ko.observable(false)
+    allDayChecked : ko.observable(true)
     startDate : ko.observable("")
     endDate : ko.observable("")
 

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -20,10 +20,10 @@ fullCalendar = ->
 
     select:
       (start, end, allDay) ->
-        starttime = moment(start).format("YYYY/MM/DD H:mm")
-        endtime = moment(end).format("YYYY/MM/DD H:mm")
-        $('#createEventModal #eventStartTime').val(starttime)
-        $('#createEventModal #eventEndTime').val(endtime)
+        starttime = moment(start).format("YYYY/MM/DD")
+        endtime = moment(end).subtract(1, 'days').format("YYYY/MM/DD")
+        $('#createEventModal #eventStartDateHidden').val(starttime).change()
+        $('#createEventModal #eventEndDateHidden').val(endtime).change()
         $('#createEventModal #eventAllDay').val(allDay)
         $('#createEventModal').modal("show")
 
@@ -75,15 +75,15 @@ doSubmit = ->
     e.preventDefault()
     $("#createEventModal").modal('hide')
     console.log($('#eventSummary').val())
-    console.log($('#eventStartTime').val())
-    console.log($('#eventEndTime').val())
+    console.log($('#eventStartDateHidden').val())
+    console.log($('#eventEndDateHidden').val())
     console.log($('#eventAllDay').val())
 
     data = {
       event:
         summary: $('#eventSummary').val()
-        dtstart: new Date($('#eventStartTime').val())
-        dtend: new Date($('#eventEndTime').val())
+        dtstart: new Date($('#eventStartDateHidden').val())
+        dtend: new Date($('#eventEndDateHidden').val())
     }
 
     $ . ajax
@@ -95,8 +95,8 @@ doSubmit = ->
         $("#calendar").fullCalendar('renderEvent',
         {
            title: $('#eventSummary').val()
-           start: new Date($('#eventStartTime').val())
-           end: new Date($('#eventEndTime').val())
+           start: new Date($('#eventStartDateHidden').val())
+           end: new Date($('#eventEndDateHidden').val())
            allDay: ($('#eventAllDay').val() == "true")
         },
         true)
@@ -184,6 +184,8 @@ ready = ->
     selectedOptionValue : ko.observable("Weekly")
     repeatChecked : ko.observable(false)
     allDayChecked : ko.observable(false)
+    startDate : ko.observable("")
+    endDate : ko.observable("")
 
   vm.repeatByWeek = ko.computed((->
     vm.selectedOptionValue() == "Weekly"
@@ -200,6 +202,12 @@ ready = ->
   ), vm)
   vm.notAllDayChecked = ko.computed((->
     !vm.allDayChecked()
+  ),vm)
+  vm.singleDay = ko.computed((->
+    vm.startDate() == vm.endDate()
+  ),vm)
+  vm.multiDays = ko.computed((->
+    vm.startDate() != vm.endDate()
   ),vm)
 
   ko.applyBindings vm

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -28,9 +28,12 @@
   display: none;
 }
 
-.form-th {
-  padding: 0px 15px 0px 0px;
-  text-align: right;
+.event-form-key {
+  padding: 0.4em 1em 0.4em 0em;
+}
+
+.event-form-val {
+  padding: 0.4em 0em;
 }
 
 .modal-repeat {

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -40,3 +40,7 @@
   width:450px;
   margin-left: 75px;
 }
+
+.set-left {
+  float: left;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,12 +16,12 @@ class EventsController < ApplicationController
     @point_date = DateTime.now.prev_year.beginning_of_month
     @point_event = Event.where("dtstart  >= ?", @point_date).order("dtstart ASC").first
     @recurrences = Recurrence.all
+    @event = Event.new
 
     respond_to do |format|
       format.html
       format.json {render json: @events.map(&:to_event)}
     end
-
   end
 
   # GET /events/1
@@ -37,6 +37,9 @@ class EventsController < ApplicationController
   # GET /events/new
   def new
     @event = Event.new
+    @event.summary = params[:event][:summary]
+    @event.dtstart = params[:event][:dtstart]
+    @event.dtend = params[:event][:dtend]
   end
 
   # GET /events/1/edit

--- a/app/views/events/_create_form_of_modal.html.erb
+++ b/app/views/events/_create_form_of_modal.html.erb
@@ -5,32 +5,48 @@
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title">New Event</h4>
       </div>
-      <div class="modal-body">
-        <form id="createEventForm" class="modal-body">
-          <label class="control-label" for="inputSummary">Summary:</label>
-          <div class="controls">
-            <div class="input-group">
-              <input type="text" id="eventSummary" class="form-control">
-            </div>
-          </div>
-          <label class="control-label" for="inputDate">Start:</label>
-          <div class="controls">
-            <div class="input-group">
-              <input type="text" id="eventStartTime" class="form-control">
-            </div>
-          </div>
-          <label class="control-label" for="inputDate">End:</label>
-          <div class="controls">
-            <div class="input-group">
-              <input type="text" id="eventEndTime" class="form-control">
-                    <input type="hidden" id="eventAllDay" />
-            </div>
-          </div>
-        </form>
-      </div>
+      <form id="createEventForm" class="modal-body">
+        <div class="modal-body">
+          <table>
+            <tbody>
+              <tr>
+                <th class="event-form-key">
+                  When:
+                </th>
+                <td class="event-form-val">
+                  <div data-bind="visible: singleDay">
+                    <span data-bind="text: startDate"></span>
+                  </div>
+                  <div data-bind="visible: multiDays">
+                    <span data-bind="text: startDate"></span>〜<span data-bind="text: endDate"></span>
+                  </div>
+                  <input type="hidden" id="eventStartDateHidden" name="eventStartDateHidden" data-bind="value: startDate" class="form-control">
+                  <input type="hidden" id="eventEndDateHidden" name="eventEndDateHidden" data-bind="value: endDate" class="form-control">
+                </td>
+              </tr>
+              <tr>
+                <th class="event-form-key">
+                  What:
+                </th>
+                <td class="event-form-val">
+                  <input type="text" id="eventSummary" class="form-control">
+                </td>
+              </tr>
+              <tr>
+                <th class="event-form-key">
+                  Calendar:
+                </th>
+                <td class="event-form-val">
+                  <select></select>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </form>
       <div class="modal-footer">
-        <button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
-        <button type="submit" class="btn btn-primary" id="submitButton">Save</button>
+        <button type="submit" class="btn set-left" id="submitButton">Creat event</button>
+        <%= link_to "Edit event »", {:controller => "events", :action => "new"}, {:class => "btn btn-link set-left"} %>
       </div>
     </div>
   </div>

--- a/app/views/events/_create_form_of_modal.html.erb
+++ b/app/views/events/_create_form_of_modal.html.erb
@@ -1,3 +1,4 @@
+<%= form_for @event , :url => {:action => 'new'} do |f| %>
 <div id="createEventModal" class="modal fade">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -20,8 +21,8 @@
                   <div data-bind="visible: multiDays">
                     <span data-bind="text: startDate"></span>〜<span data-bind="text: endDate"></span>
                   </div>
-                  <input type="hidden" id="eventStartDateHidden" name="eventStartDateHidden" data-bind="value: startDate" class="form-control">
-                  <input type="hidden" id="eventEndDateHidden" name="eventEndDateHidden" data-bind="value: endDate" class="form-control">
+                  <%= f.hidden_field :dtstart, :id => 'eventStartDateHidden', 'data-bind' => "value: startDate" %>
+                  <%= f.hidden_field :dtend, :id => 'eventEndDateHidden', 'data-bind' => "value: endDate" %>
                 </td>
               </tr>
               <tr>
@@ -29,7 +30,7 @@
                   What:
                 </th>
                 <td class="event-form-val">
-                  <input type="text" id="eventSummary" class="form-control">
+                  <%= f.text_field :summary, :id => 'eventSummary' %>
                 </td>
               </tr>
               <tr>
@@ -46,8 +47,9 @@
       </form>
       <div class="modal-footer">
         <button type="submit" class="btn set-left" id="submitButton">Creat event</button>
-        <%= link_to "Edit event »", {:controller => "events", :action => "new"}, {:class => "btn btn-link set-left"} %>
+        <%= f.submit "Edit event »", {:class => "btn btn-link set-left"} %>
       </div>
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -48,15 +48,15 @@
                 <th class="form-th">
                   <%= f.label :Where %>
                 </th>
-                <td>
+                <td class="event-form-val">
                   <%= f.text_field :location, :placeholder => "Enter a location" %>
                 </td>
               </tr>
               <tr>
-                <th valign="top" class="form-th">
+                <th valign="top" class="event-form-key">
                   <%= f.label :description %>
                 </th>
-                <td>
+                <td class="event-form-val">
                   <%= f.text_area :description %>
                 </td>
               </tr>
@@ -78,27 +78,27 @@
           <table align="center">
             <tbody>
               <tr>
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeats:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <select data-bind="options: optionValues, value: selectedOptionValue" class="repeat-type"></select>
                 </td>
               </tr>
               <tr data-bind="visible: repeatByWeek">
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeat every:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <select data-bind="options: optionNum"></select>
                   weeks
                 </td>
               </tr>
               <tr data-bind="visible: repeatByWeek">
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeat on:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <input type="checkbox" name="wday" value="1">S
                   <input type="checkbox" name="wday" value="2">M
                   <input type="checkbox" name="wday" value="3">T
@@ -109,55 +109,55 @@
                 </td>
               </tr><!-- /.weekly -->
               <tr data-bind="visible: repeatByMonth">
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeat every:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <select data-bind="options: optionNum"></select>
                   months
                 </td>
               </tr>
               <tr data-bind="visible: repeatByMonth">
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeat by:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <input type="radio" name="repeat_by_month" value="by_month" checked>day of the month
                   <input type="radio" name="repeat_by_week" value="by_week">day of the week
                 </td>
               </tr><!-- /.monthly -->
               <tr data-bind="visible: repeatByYear">
-                <th class="form-th">
+                <th class="event-form-key">
                   Repeat every:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <select data-bind="options: optionNum"></select>
                   years
                 </td>
               </tr><!-- /.yearly -->
               <tr>
-                <th class="form-th">
+                <th class="event-form-key">
                   Starts on:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <input type="text" value="Select date" disabled="disabled" />
                 </td>
               </tr>
               <tr>
-                <th valign="top" class="form-th">
+                <th valign="top" class="event-form-key">
                   Ends:
                 </th>
-                <td>
+                <td class="event-form-val">
                   <input type="radio" name="never" checked> Never <br>
                   <input type="radio" name="times"> After <input type="text" size="5" name="tims_input" value="15"> occurrences <br>
                   <input type="radio" name="until"> On <input type="date" name="until_input">
                 </td>
               </tr>
               <tr>
-                <th class="form-th">
+                <th class="event-form-key">
                   Summary:
                 </th>
-                <td>
+                <td class="event-form-val">
                   Summary
                 </td>
               </tr>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module Camome
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   post "gate/login"
 
   match "events/create_recurrence", :via => :post
+  post "events/new"
 
   get "inbox/missions"
   get "inbox/recurrences"


### PR DESCRIPTION
#25 に対するPRである． 

予定を作成するモーダルの見た目をGoogleカレンダーに合わせた．
また，モーダルから予定編集画面に遷移するリンクを追加した．
このとき，モーダルに入力された予定名や予定の開始日と終了日が埋まった状態で遷移する．
 