### PR TITLE
Organize calendar and authentication related models

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -8,6 +8,7 @@ require 'uri'
 class Calendar < ActiveRecord::Base
   has_many :events, dependent: :destroy
   belongs_to :user
+  belongs_to :calendar_provider
   has_one :auth_info, as: :parent,
   class_name: "CalendarAuthInfo", dependent: :destroy
 

--- a/app/models/calendar_auth_info.rb
+++ b/app/models/calendar_auth_info.rb
@@ -1,3 +1,0 @@
-class CalendarAuthInfo < AuthInfo
-  belongs_to :calendar
-end

--- a/app/models/calendar_provider.rb
+++ b/app/models/calendar_provider.rb
@@ -1,0 +1,8 @@
+class CalendarProvider < ActiveRecord::Base
+  has_many :calendars
+
+  def list(user)
+    ## Return Provider list tied to user
+    ## If there is no available provider, return nil
+  end
+end

--- a/app/models/google_calendar_auth_info.rb
+++ b/app/models/google_calendar_auth_info.rb
@@ -1,0 +1,2 @@
+class GoogleCalendarAuthInfo < AuthInfo
+end

--- a/app/models/google_calendar_provider.rb
+++ b/app/models/google_calendar_provider.rb
@@ -1,2 +1,3 @@
 class GoogleCalendarProvider < CalendarProvider
+  has_one :google_calendar_auth_info, as: :parent, dependent: :destroy
 end

--- a/app/models/google_calendar_provider.rb
+++ b/app/models/google_calendar_provider.rb
@@ -1,0 +1,2 @@
+class GoogleCalendarProvider < CalendarProvider
+end

--- a/app/models/master_auth_info.rb
+++ b/app/models/master_auth_info.rb
@@ -1,3 +1,2 @@
 class MasterAuthInfo < AuthInfo
-  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :invitable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
   has_many :calendars, dependent: :destroy
-  has_one :auth_info, as: :parent,
-  class_name: "MasterAuthInfo", dependent: :destroy
+  has_one :master_auth_info, as: :parent, dependent: :destroy
 
   attr_accessor :master_pass
 

--- a/db/migrate/20161222032416_create_calendar_providers.rb
+++ b/db/migrate/20161222032416_create_calendar_providers.rb
@@ -1,0 +1,8 @@
+class CreateCalendarProviders < ActiveRecord::Migration
+  def change
+    create_table :calendar_providers do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161222035859_add_type_to_calendar_provider.rb
+++ b/db/migrate/20161222035859_add_type_to_calendar_provider.rb
@@ -1,0 +1,5 @@
+class AddTypeToCalendarProvider < ActiveRecord::Migration
+  def change
+    add_column :calendar_providers, :type, :string
+  end
+end

--- a/db/migrate/20161222041333_add_calendar_provider_id_to_calendar.rb
+++ b/db/migrate/20161222041333_add_calendar_provider_id_to_calendar.rb
@@ -1,0 +1,5 @@
+class AddCalendarProviderIdToCalendar < ActiveRecord::Migration
+  def change
+    add_column :calendars, :calendar_provider_id, :integer
+  end
+end

--- a/db/migrate/20161222041502_add_user_id_to_calendar_provider.rb
+++ b/db/migrate/20161222041502_add_user_id_to_calendar_provider.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCalendarProvider < ActiveRecord::Migration
+  def change
+    add_column :calendar_providers, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161013043526) do
+ActiveRecord::Schema.define(version: 20161222041502) do
+
   create_table "auth_infos", force: true do |t|
     t.string   "login_name"
     t.string   "encrypted_pass"
@@ -26,6 +27,13 @@ ActiveRecord::Schema.define(version: 20161013043526) do
     t.string   "refresh_token"
   end
 
+  create_table "calendar_providers", force: true do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "type"
+    t.integer  "user_id"
+  end
+
   create_table "calendars", force: true do |t|
     t.string   "displayname"
     t.string   "color"
@@ -33,6 +41,7 @@ ActiveRecord::Schema.define(version: 20161013043526) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
+    t.integer  "calendar_provider_id"
   end
 
   create_table "clam_events", force: true do |t|
@@ -160,7 +169,6 @@ ActiveRecord::Schema.define(version: 20161013043526) do
     t.string   "invited_by_type"
     t.integer  "invitations_count",      default: 0
     t.string   "auth_name"
-    t.string   "api_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/models/calendar_provider_spec.rb
+++ b/spec/models/calendar_provider_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CalendarProvider, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#43 に対する PR である．

### やったこと

1. CalendarProvider を作成
2. CalendarProvider を継承した GoogleCalendarProvider を作成
3. CalendarProvider と Calendar の間に一対多の関連を作成
4. CalendarProvider と User の間に薄い一対一の関連を作成

4.に関して User が直接 CalendarProvider を使用することはない(CalendarProvider は Calendar から使用される)．
このため，本来は一対多の関連は必要ない．
しかし，CalendarProvider と User の間には，「CalendarProvider は User に所有されている」という関連が必要である．
このため，リレーション関係は明示しないが，CalendarProvider に user_id というカラムを作成し，所有されていることを表現した．


### できていないこと

1. GoogleCalendarAuthInfo を作成する
2. GoogleCalendarAuthInfo と GoogleCalendarProvider の間に関係を作る