### PR TITLE
Output json for request when event creating

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -140,37 +140,39 @@ ready = ->
         )
       $('#calendar').css('width','80%')
 
-  $('#eventStartTime').datetimepicker
-    format: "YYYY/MM/DD H:mm"
-    icons:
-      time: "fa fa-clock-o"
-      date: "fa fa-calendar"
-      up: "fa fa-chevron-up"
-      down: "fa fa-chevron-down"
-      previous: "fa fa-chevron-left"
-      next: "fa fa-chevron-right"
+  $('#allDay').on
+    mouseleave: ->
+      $('#eventStartTime').datetimepicker
+        format: "YYYY/MM/DD H:mm"
+        icons:
+          time: "fa fa-clock-o"
+          date: "fa fa-calendar"
+          up: "fa fa-chevron-up"
+          down: "fa fa-chevron-down"
+          previous: "fa fa-chevron-left"
+          next: "fa fa-chevron-right"
 
-  $('#eventEndTime').datetimepicker
-    format: "YYYY/MM/DD H:mm"
-    icons:
-      time: "fa fa-clock-o"
-      date: "fa fa-calendar"
-      up: "fa fa-chevron-up"
-      down: "fa fa-chevron-down"
-      previous: "fa fa-chevron-left"
-      next: "fa fa-chevron-right"
+      $('#eventEndTime').datetimepicker
+        format: "YYYY/MM/DD H:mm"
+        icons:
+          time: "fa fa-clock-o"
+          date: "fa fa-calendar"
+          up: "fa fa-chevron-up"
+          down: "fa fa-chevron-down"
+          previous: "fa fa-chevron-left"
+          next: "fa fa-chevron-right"
 
-  $('#eventStartDate').datetimepicker
-    format: "YYYY/MM/DD"
-    icons:
-      previous: "fa fa-chevron-left"
-      next: "fa fa-chevron-right"
+      $('#eventStartDate').datetimepicker
+        format: "YYYY/MM/DD"
+        icons:
+          previous: "fa fa-chevron-left"
+          next: "fa fa-chevron-right"
 
-  $('#eventEndDate').datetimepicker
-    format: "YYYY/MM/DD"
-    icons:
-      previous: "fa fa-chevron-left"
-      next: "fa fa-chevron-right"
+      $('#eventEndDate').datetimepicker
+        format: "YYYY/MM/DD"
+        icons:
+          previous: "fa fa-chevron-left"
+          next: "fa fa-chevron-right"
 
   $('#myTab a:last').tab('show')
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -52,6 +52,11 @@ class EventsController < ApplicationController
       @clam.events << @event
     end
 
+    json = event_to_json(@event)
+    puts "----------------------"
+    puts json
+    puts "----------------------"
+
     respond_to do |format|
       if @event.save
         format.html { redirect_to @event, notice: 'Event was successfully created.' }
@@ -124,6 +129,22 @@ class EventsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def event_params
-      params.require(:event).permit(:uid, :categories, :description, :location, :status, :summary, :dtstart, :dtend, :recurrence_id, :related_to, :exdate, :rdate, :created, :last_modified, :sequence, :rrule)
+      params.require(:event).permit(:uid, :categories, :description, :location, :status, :summary, :dtstart, :dtend, :recurrence_id, :related_to, :exdate, :rdate, :created, :last_modified, :sequence, :rrule, :all_day)
+    end
+
+    def event_to_json(event)
+      e = {}
+      if event.all_day
+        e["end"] = {"date" => event.dtend, "timeZone" => "Asia/Tokyo"}
+        e["start"] = {"date" => event.dtstart, "timeZone" => "Asia/Tokyo"}
+      else
+        e["end"] = {"dateTime" => event.dtend, "timeZone" => "Asia/Tokyo"}
+        e["start"] = {"dateTime" => event.dtstart, "timeZone" => "Asia/Tokyo"}
+      end
+      e["summary"] = event.summary
+      e["location"] = event.location
+      e["description"] = event.description
+
+      return e.to_json
     end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -22,14 +22,16 @@
   <div class="field">
     <%= f.text_field :summary, :placeholder => "Untitled event" %>
   </div>
-  <div class="field input-group" data-bind="visible: notAllDayChecked">
-    <%= f.text_field :dtstart, id:"eventStartTime" %>  to  <%= f.text_field :dtend, id:"eventEndTime" %>
-  </div>
-  <div class="field input-group" data-bind="visible: allDayChecked">
-    <%= f.text_field :dtstart, id:"eventStartDate" %>  to  <%= f.text_field :dtend, id:"eventEndDate" %>
+  <div class="field input-group">
+    <div data-bind="if: notAllDayChecked">
+      <%= f.text_field :dtstart, id:"eventStartTime" %>  to  <%= f.text_field :dtend, id:"eventEndTime" %>
+    </div>
+    <div data-bind="if: allDayChecked">
+      <%= f.text_field :dtstart, id:"eventStartDate" %>  to  <%= f.text_field :dtend, id:"eventEndDate" %>
+    </div>
   </div>
   <div>
-    <input type="checkbox" data-bind="checked: allDayChecked"> All day
+    <input type="checkbox" id="allDay" name="event[all_day]" value="true" data-bind="checked: allDayChecked"> All day
     <input type="checkbox" data-bind="checked: repeatChecked"> Repeat...
   </div>
   <ul class="nav nav-tabs" role="tablist">
@@ -67,7 +69,7 @@
     </div>
   </div>
 
-  <div class="modal fade" id="repeatSettings" tabindex="-1" role="dialog">
+  <div class="modal fade" id="repeatSettings" tabindex="-1" role="dialog" data-bind="if: repeatChecked">
     <div class="modal-dialog">
       <div class="modal-content modal-repeat">
         <div class="modal-header">
@@ -174,7 +176,7 @@
 
   <%= f.hidden_field :categories %>
   <%= f.hidden_field :status %>
-  <%= f.hidden_field :recurrence_id, :value => "Inbox" %>
+  <%= f.hidden_field :recurrence_id, :value => "1" %>
   <%= f.hidden_field :related_to %>
   <%= f.hidden_field :uid %>
   <%= f.hidden_field :created %>

--- a/db/migrate/20170112093241_add_all_day_to_events.rb
+++ b/db/migrate/20170112093241_add_all_day_to_events.rb
@@ -1,0 +1,5 @@
+class AddAllDayToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :all_day, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161222041502) do
+ActiveRecord::Schema.define(version: 20170112093241) do
 
   create_table "auth_infos", force: true do |t|
     t.string   "login_name"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 20161222041502) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "calendar_id"
+    t.boolean  "all_day"
   end
 
   create_table "missions", force: true do |t|


### PR DESCRIPTION
#25 に対するPRである．

予定作成時にgoogleカレンダーにリクエストできるような形式のJSONを出力するようにした．
具体的な変更点は以下の3つである．
+ 表示していない要素をPOSTしないようにifバインディングを使用
+ 終日の設定が行えるようにeventモデルにall-dayを追加
+ 予定生成時にJSONを出力

今後の課題として以下の4つがある．
+ 予定変更時にもJSONを出力
+ カレンダを指定できるように変更
+ 繰り返しの設定を反映できるように変更(RRULEの生成)
+ GoogleカレンダーへのPOST機能の実装