### PR TITLE
Create duplicate modal

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -35,22 +35,12 @@ fullCalendar = ->
         dtstart = moment(dtstart).hour(moment(origin_dtstart).hour())
         dtstart = moment(dtstart).minute(moment(origin_dtstart).minute())
         dtend = moment(dtstart).add(duration,'seconds')
-        data = {
-          event:
-            summary: $(this).data('event').title
-            dtstart: new Date(dtstart)
-            dtend: new Date(dtend)
-            origin_event_id: $(this).data('event').id
-        }
-
-        $ . ajax
-          type: 'POST'
-          url: '/events/ajax_create_event_from_old_event'
-          data: data
-          timeout: 9000
-          success: ->
-          error: ->
-            alert "error"
+        summary = $(this).data('event').title
+        $('#duplicateEventModal #startTime').val(moment(dtstart).format("YYYY/MM/DD H:mm"))
+        $('#duplicateEventModal #endTime').val(moment(dtend).format("YYYY/MM/DD H:mm"))
+        $('#duplicateEventModal #duplicateEventSummary').val(summary)
+        $('#duplicateEventModal #originalId').val($(this).data('event').id)
+        $('#duplicateEventModal').modal("show")
 
     eventAfterAllRender:
       (view) ->
@@ -100,6 +90,27 @@ doSubmit = ->
            allDay: ($('#eventAllDay').val() == "true")
         },
         true)
+      error: ->
+        alert "error"
+
+  $('#duplicateButton').on 'click', (e) ->
+    e.preventDefault()
+    $("#duplicateEventModal").modal('hide')
+
+    data = {
+      event:
+        summary: $('#duplicateEventSummary').val()
+        dtstart: new Date($('#startTime').val())
+        dtend: new Date($('#endTime').val())
+        origin_event_id: $('#originalId').val()
+    }
+
+    $ . ajax
+      type: 'POST'
+      url: '/events/ajax_create_event_from_old_event'
+      data: data
+      timeout: 9000
+      success: ->
       error: ->
         alert "error"
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -46,7 +46,7 @@ class EventsController < ApplicationController
   # POST /events.json
   def create
     @event = Event.new(event_params)
-    @event.recurrence_id = Recurrence.inbox.id
+    @event.recurrence_id = @event.object_id
     if params[:clam_id] != nil
       @clam = Clam.find(params[:clam_id])
       @clam.events << @event

--- a/app/views/events/_duplicate_form_of_modal.html.erb
+++ b/app/views/events/_duplicate_form_of_modal.html.erb
@@ -1,0 +1,48 @@
+<%= form_for @event , :url => {:action => 'new'} do |f| %>
+<div id="duplicateEventModal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Duplicate Event</h4>
+      </div>
+      <form id="createEventForm" class="modal-body">
+        <div class="modal-body">
+          <table>
+            <tbody>
+              <tr>
+                <th class="event-form-key">
+                  When:
+                </th>
+                <td class="event-form-val">
+                    <%= f.text_field :dtstart, :id => 'startTime' %>  to  <%= f.text_field :dtend, :id => 'endTime' %>
+                </td>
+              </tr>
+              <tr>
+                <th class="event-form-key">
+                  What:
+                </th>
+                <td class="event-form-val">
+                  <%= f.text_field :summary, :id => 'duplicateEventSummary' %>
+                </td>
+              </tr>
+              <tr>
+                <th class="event-form-key">
+                  Calendar:
+                </th>
+                <td class="event-form-val">
+                  <select></select>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <%= f.hidden_field :recurrence, :id => 'originalId' %>
+        </div>
+      </form>
+      <div class="modal-footer">
+        <button type="submit" class="btn set-left" id="duplicateButton">Duplicate event</button>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,6 +8,6 @@
 </div>
 <%= render :partial => "events/side_menu" , :locals => {:events => @events, :point_event => @point_event} %>
 <%= render :partial => "events/create_form_of_modal" %>
+<%= render :partial => "events/duplicate_form_of_modal" %>
 <div id="calendar"></div>
 <%= render :partial => "events/recurrence" , :locals => {:recurrences => @recurrences} %>
-


### PR DESCRIPTION
old eventsの予定をドラッグ&ドロップにより複製した際に，モーダルを表示するようにした．
モーダルでは以下の変更を行えるようにした．
* 予定名
* 予定の開始時刻と終了時刻

予定を複製する際，元の予定の`recurrence_id`と同じ値をもつように予定を複製していた．
また，予定を新規作成する際，`recurrence_id`には`Recurrence.inbox.id`を与えていた．
これは，作成された予定はまずはinboxに属するものとして，その後，整理することを想定していたと考えられる．

カレンダでold eventsから予定を複製することを考えた場合，新規予定作成時に予定に固有の`recurrence_id`を与えておく必要がある．
この理由は，新規作成した予定は既存のリカーレンスに属さず，リカーレンスに属する予定はold eventsから複製すると考えられるためである．
このため，予定を新規作成する際，`recurrence_id`にはEventオブジェクトのidを与えることにした．

