### PR TITLE
Fix bug of updating master_pass

### DIFF
--- a/app/models/key_vault.rb
+++ b/app/models/key_vault.rb
@@ -24,7 +24,7 @@ class KeyVault
                      user.master_pass,
                      auth_info.salt)
     else
-      auth_info.decrypted_pass = 
+      auth_info.decrypted_pass =
         decrypt_word([auth_info.encrypted_pass].pack("H*"),
                      user.master_auth_info.decrypted_pass,
                      auth_info.salt)
@@ -52,18 +52,18 @@ class KeyVault
       decrypt_word([auth_info.token].pack("H*"),
                    auth_info.decrypted_pass,
                    auth_info.salt)
-    
+
     auth_info.decrypted_token[:refresh_token] =
       decrypt_word([auth_info.refresh_token].pack("H*"),
                    auth_info.decrypted_pass,
                    auth_info.salt)
-    
+
     return auth_info
   end
 
   def self.crypt_word(word, secret_key, salt)
     cipher = OpenSSL::Cipher::Cipher.new("AES-256-CBC")
-    cipher.padding = 0
+    cipher.padding = 1
     cipher.encrypt
     cipher.pkcs5_keyivgen(secret_key, salt)
     cipher.update(word) + cipher.final
@@ -72,7 +72,7 @@ class KeyVault
 
   def self.decrypt_word(word, secret_key, salt)
     cipher = OpenSSL::Cipher::Cipher.new("AES-256-CBC")
-    cipher.padding = 0
+    cipher.padding = 1
     cipher.decrypt
     cipher.pkcs5_keyivgen(secret_key, salt)
     cipher.update(word) + cipher.final


### PR DESCRIPTION
パスワードを変更する場合，前のパスワードでtokenを復号化し，新しいパスワードでtokenを暗号化する．
#52 のPRでは，新しいパスワードでtokenを暗号化するところで，前のパスワードを用いてしまっていたため，本PRで修正している．

また，暗号化・復号化時のパディングを無効から有効に変更した．
これは，#52 時点では，無効の状態で動作したが，
改めて動作確認を行うと，有効にしないと動作しなかった．
パディングついては，今後調査する．

以下の問題点が残っているため，これらの解消に取り組む．
+ tokenを保存していない場合，パスワードの変更が行えない．
+ パスワードが間違っている場合，エラーが発生する．
