### PR TITLE
Store token before show calendar page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ config/application_settings.yml
 bower.json
 
 attic/
+
+config/environments/development.rb

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ require 'date'
 
 class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :exist_token?, only: [:index]
 
   # GET /events
   # GET /events.json
@@ -11,13 +12,6 @@ class EventsController < ApplicationController
       @events = Event.where(recurrence_id: recurrence_id).order("dtstart DESC")
     else
       @events = Event.all.order("dtstart DESC")
-    end
-
-    ds = DataStore::RedisStore.new
-    if ds.load(User.current.auth_name)==nil
-      auth_info = User.current.master_auth_info
-      auth_info = KeyVault.decrypt_token(auth_info)
-      ds.store(User.curent.auth_name, { :token => auth_info.decrypted_token[:token], :refresh_token => auth_info.decrypted_token[:refresh_token] })
     end
 
     @point_date = DateTime.now.prev_year.beginning_of_month
@@ -136,7 +130,22 @@ class EventsController < ApplicationController
     render json: events
   end
 
+  def input_master_pass
+  end
+
+  def set_token
+    user = current_user
+    user.master_pass = params[:password]
+    master_auth_info = MasterAuthInfo.where(:parent_id => user.id, :parent_type => user.class.name).first
+    unlocked_auth_info = KeyVault.unlock(master_auth_info, user)
+    auth_info = KeyVault.decrypt_token(unlocked_auth_info)
+    ds = DataStore::RedisStore.new
+    ds.store(user.auth_name, { :token => auth_info.decrypted_token[:token], :refresh_token => auth_info.decrypted_token[:refresh_token] })
+    redirect_to :action => "index"
+  end
+
   private
+
   # Use callbacks to share common setup or constraints between actions.
   def set_event
     @event = Event.find(params[:id])
@@ -161,4 +170,12 @@ class EventsController < ApplicationController
     e["description"] = event.description
     return e.to_json
   end# end event_to_json
+
+  def exist_token?
+    ds = DataStore::RedisStore.new
+    user = current_user
+    if ds.load(user.auth_name) == nil
+      redirect_to :action => "input_master_pass"
+    end
+  end
 end# end EventsController

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -140,7 +140,7 @@ class EventsController < ApplicationController
     unlocked_auth_info = KeyVault.unlock(master_auth_info, user)
     auth_info = KeyVault.decrypt_token(unlocked_auth_info)
     ds = DataStore::RedisStore.new
-    ds.store(user.auth_name, { :token => auth_info.decrypted_token[:token], :refresh_token => auth_info.decrypted_token[:refresh_token] })
+    ds.store(user.auth_name, { :token => auth_info.decrypted_token[:token], :refresh_token => auth_info.decrypted_token[:refresh_token] }.to_json)
     redirect_to :action => "index"
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -174,7 +174,7 @@ class EventsController < ApplicationController
   def exist_token?
     ds = DataStore::RedisStore.new
     user = current_user
-    if ds.load(user.auth_name) == nil
+    if ds.load(user.auth_name) == nil && user.master_auth_info.token != nil
       redirect_to :action => "input_master_pass"
     end
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,13 @@ class EventsController < ApplicationController
       @events = Event.all.order("dtstart DESC")
     end
 
+    ds = DataStore::RedisStore.new
+    if ds.load(User.current.auth_name)==nil
+      auth_info = User.current.master_auth_info
+      auth_info = KeyVault.decrypt_token(auth_info)
+      ds.store(User.curent.auth_name, { :token => auth_info.decrypted_token[:token], :refresh_token => auth_info.decrypted_token[:refresh_token] })
+    end
+
     @point_date = DateTime.now.prev_year.beginning_of_month
     @point_event = Event.where("dtstart  >= ?", @point_date).order("dtstart ASC").first
     @recurrences = Recurrence.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,7 +73,12 @@ class UsersController < ApplicationController
       token = Digest::SHA1.hexdigest(current_user.name + DateTime.new.to_s)
       session[:app_token] = token
       session[:decrypted_pass] = auth_info.decrypted_pass
-      redirect_to omniauth_authorize_path(:user, :google_oauth2, :token => token, :state => "application")
+      ds = DataStore::RedisStore.new
+      if ds.load(current_user.auth_name) == nil
+        redirect_to omniauth_authorize_path(:user, :google_oauth2, :token => token, :state => "application")
+      else
+        redirect_to omniauth_authorize_path(:user, :google_oauth2, :token => token, :state => "update")
+      end
     rescue
       flash[:error] = "Invalid password or Password has not been set"
       redirect_to '/users/edit/applications'

--- a/app/views/events/input_master_pass.html.erb
+++ b/app/views/events/input_master_pass.html.erb
@@ -1,0 +1,12 @@
+<h2>Input your password</h2>
+
+<%= form_tag('/events/set_token', method: "POST") do %>
+  <div class="field">
+    <%= label_tag "Input password" %><br />
+    <%= password_field_tag "password" %>
+  </div>
+
+  <div class="actions">
+    <%= submit_tag "Continue" %>
+  </div>
+<% end %>

--- a/config/environments/development.sample.rb
+++ b/config/environments/development.sample.rb
@@ -1,0 +1,47 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  # Raise an error on page load if there are pending migrations.
+  config.active_record.migration_error = :page_load
+
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    user_name: 'username@gmail.com',
+    password: 'password',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,10 @@ Rails.application.routes.draw do
   match "events/create_recurrence", :via => :post
   post "events/new"
   get "events/list"
+
+  get "events/input_master_pass", to: "events#input_master_pass"
+  post "events/set_token", to: "events#set_token"
+
   resources :events
 
   get "inbox/missions"


### PR DESCRIPTION
#49 に対するPRである．
本PRは，#56 の commit を含んでいる．

カレンダのページを表示する際に，token が保存されていない場合，
master_pass を要求する画面に遷移するようにした．
master_pass 入力後は，復号化した token を Redis に保存する．
保存する際の key は，ユーザの auth_name (認証の際に使用したメールアドレス)である．
value は，token と refresh_token を含む hash である．

ここで，本PR作成時の RedisStore クラスの load メソッドでは保存した token が読み込めなかった．
これは，load メソッド内でエラーが発生し，`nil` が帰ってきていると考えられる．
[第143回GN談話会での議論](http://jay.swlab.cs.okayama-u.ac.jp/minutes/492?ai=0403)から，シンプルな load メソッドに変更されると考え，
以下のような load メソッドで実験したところ，想定通りの動作となった．
```
def load (key)
  @redis.get(key)
end
```

## 残された課題
+ token を保存していない場合，カレンダが開けない
+ Redis に保存後，goohub に token を渡す処理の作成