### PR TITLE
Bugfix for PR#56

### DIFF
--- a/app/models/key_vault.rb
+++ b/app/models/key_vault.rb
@@ -63,7 +63,6 @@ class KeyVault
 
   def self.crypt_word(word, secret_key, salt)
     cipher = OpenSSL::Cipher::Cipher.new("AES-256-CBC")
-    cipher.padding = 1
     cipher.encrypt
     cipher.pkcs5_keyivgen(secret_key, salt)
     cipher.update(word) + cipher.final
@@ -72,7 +71,6 @@ class KeyVault
 
   def self.decrypt_word(word, secret_key, salt)
     cipher = OpenSSL::Cipher::Cipher.new("AES-256-CBC")
-    cipher.padding = 1
     cipher.decrypt
     cipher.pkcs5_keyivgen(secret_key, salt)
     cipher.update(word) + cipher.final


### PR DESCRIPTION
#56 に対する修正を行ったPRである．

本PRでは以下の２点を行った．
+ tokenを保存していない場合でもパスワードを変更できるようにした．
+ KeyVault.rbのcrypt_word，decrypt_wordで明示的にパディングを有効にしていたが，デフォルトで有効となるため削除した．([第144回GN談話会での議論](http://jay.swlab.cs.okayama-u.ac.jp/minutes/495?ai=0384))