### PR TITLE
Adjust RedisStore class and GoogleCalendar::Calendar class

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -20,8 +20,8 @@ class EventsController < ApplicationController
     @event = Event.new
 
     data_store = DataStore.create(:redis)
-    @calendars = data_store.load("calendars")
-    
+    @calendars = JSON.parse(data_store.load("calendars"))
+
     respond_to do |format|
       format.html
       format.json {render json: @events.map(&:to_event)}
@@ -130,7 +130,11 @@ class EventsController < ApplicationController
     cal = GoogleCalendar::Calendar.new(DataStore.create(:redis))
     date_start = Date.parse(params["start"])
     date_end = Date.parse(params["end"])
-    events = cal.scan(date_start, date_end)
+    begin
+      events = cal.scan(date_start, date_end)
+    rescue JSON::ParserError => e
+      logger.warn("There are invalid format events.")
+    end
     render json: events
   end
 

--- a/app/models/google_calendar/calendar.rb
+++ b/app/models/google_calendar/calendar.rb
@@ -3,8 +3,8 @@ module GoogleCalendar
     def initialize(data_store)
       @data_store = data_store
       @calendars = {}
-      calendars = @data_store.load("calendars")
-      calendars["calendars"]["items"].each do |calendar|
+      calendars = JSON.parse(@data_store.load("calendars"))
+      calendars["items"].each do |calendar|
         @calendars["#{calendar["id"]}"] = calendar
       end
     end
@@ -15,13 +15,11 @@ module GoogleCalendar
       month_list.each do |date|
         month = "#{date.year}-#{date.month}"
         @data_store.glob("*-#{month}").each do |key|
-          begin
-            events = JSON.parse(@data_store.load(key))
-            events["items"].each do |event|
-              collection << GoogleCalendar::Event.new(event).to_fullcalendar
-            end
-          rescue
-            Rails.logger.warn("There are invalid format events.")
+          calendar_id = key.split("-")[0]
+          color = @calendars["#{calendar_id}"]["background_color"]
+          events = JSON.parse(@data_store.load(key))
+          events["items"].each do |event|
+            collection << GoogleCalendar::Event.new(event,color).to_fullcalendar
           end
         end
       end

--- a/app/models/google_calendar/calendar.rb
+++ b/app/models/google_calendar/calendar.rb
@@ -14,14 +14,14 @@ module GoogleCalendar
       collection = []
       month_list.each do |date|
         month = "#{date.year}-#{date.month}"
-        events = @data_store.load("*-#{month}")
-        if events != nil then
-          events.each do |k, v|
-            calendar_id = k.split("-")[0]
-            color = @calendars["#{calendar_id}"]["background_color"]
-            v["items"].each do |event|
-              collection << GoogleCalendar::Event.new(event,color).to_fullcalendar
+        @data_store.glob("*-#{month}").each do |key|
+          begin
+            events = JSON.parse(@data_store.load(key))
+            events["items"].each do |event|
+              collection << GoogleCalendar::Event.new(event).to_fullcalendar
             end
+          rescue
+            Rails.logger.warn("There are invalid format events.")
           end
         end
       end

--- a/app/models/redis_store.rb
+++ b/app/models/redis_store.rb
@@ -5,44 +5,19 @@ module DataStore
     end
 
     def load(key)
-      begin
-        h = {}
-        separate_key(key) do |k|
-          h[k] = JSON.parse(@redis.get(k))
-        end
-        h
-      rescue
-        nil
-      end
+      @redis.get(key)
     end
 
     def store(key,value)
-      separate_key(key) do |k|
-        @redis.set(k, value)
-      end
+      @redis.set(key, value)
     end
 
     def delete(key)
-      separate_key(key) do |k|
-        @redis.del(k)
-      end
+      @redis.del(key)
     end
 
-    private
-
-    def match_patterns(pattern)
+    def glob(pattern)
       @redis.keys(pattern)
-    end
-
-    def separate_key(key, &block)
-      if key["*"] then
-        keys = match_patterns(key)
-        keys.each do |k|
-          yield k
-        end
-      else
-        yield key
-      end
     end
   end# end RedisStore
 end# end DataStore

--- a/app/views/events/_calendar_list.html.erb
+++ b/app/views/events/_calendar_list.html.erb
@@ -1,5 +1,5 @@
 <div id="external-calendars">
-  <% calendars["calendars"]["items"].each do |c| %>
+  <% calendars["items"].each do |c| %>
   <div>
   <font color=<%= c["background_color"] %>>■</font><%= c["summary"] %>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,5 @@ module Camome
     # config.i18n.default_locale = :de
 
     config.time_zone = 'Tokyo'
-    config.logger = Logger.new('log/development.log')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module Camome
     # config.i18n.default_locale = :de
 
     config.time_zone = 'Tokyo'
+    config.logger = Logger.new('log/development.log')
   end
 end


### PR DESCRIPTION
#53 に対するPRである．
### 作業内容
+ `RedisStore`クラスにワイルドカード展開の処理を行う`glob`メソッドを作成し，`load`, `store`, `delete`メソッドを単純な処理に変更した．`glob`メソッドは`pattern`を引数にとり，`pattern`に該当するキーを返り値とする．
+ `GoogleCalendar::Calendar`クラスの`scan`メソッドで，RedisサーバからJSON形式以外のデータを取得した際の処理として，動作は終了させず`logger`メソッドによって警告を出力するように変更した．`logger`メソッドは引数をlogとして出力する．`logger`メソッドの出力先は`config/application.rb`で指定する．