### PR TITLE
Make it possible to pass block to glob method in RedisStore

### DIFF
--- a/app/models/google_calendar/calendar.rb
+++ b/app/models/google_calendar/calendar.rb
@@ -14,7 +14,7 @@ module GoogleCalendar
       collection = []
       month_list.each do |date|
         month = "#{date.year}-#{date.month}"
-        @data_store.glob("*-#{month}").each do |key|
+        @data_store.glob("*-#{month}") do |key|
           calendar_id = key.split("-")[0]
           color = @calendars["#{calendar_id}"]["background_color"]
           events = JSON.parse(@data_store.load(key))

--- a/app/models/redis_store.rb
+++ b/app/models/redis_store.rb
@@ -16,8 +16,15 @@ module DataStore
       @redis.del(key)
     end
 
-    def glob(pattern)
-      @redis.keys(pattern)
+    def glob(pattern, &block)
+      keys = @redis.keys(pattern)
+      if block_given?
+        keys.each do |key|
+          yield key
+        end
+      else
+        keys
+      end
     end
   end# end RedisStore
 end# end DataStore


### PR DESCRIPTION
#53 に対するPRである．
### 作業内容
`RedisStore`クラスの`glob`メソッドの引数として，ブロックが渡せるように変更した．
引数にブロックがない場合は，引数`pattern`に一致するキーを返す.

参考: https://github.com/nomlab/goohub/pull/16