### PR TITLE
Add a funtion that toggle event display

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -140,6 +140,15 @@ ready = ->
         )
       $('#calendar').css('width','80%')
 
+  $('.event_view_switch').click ->
+    if $(this).is(':checked')
+      $('.' + selectorEscape($(this).val())).show()
+    else
+      $('.' + selectorEscape($(this).val())).hide()
+
+  selectorEscape = (val) ->
+    val.replace /[ !"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~]/g, '\\$&'
+
   $('#allDay').on
     mouseleave: ->
       $('#eventStartTime').datetimepicker

--- a/app/models/google_calendar/calendar.rb
+++ b/app/models/google_calendar/calendar.rb
@@ -19,7 +19,7 @@ module GoogleCalendar
           color = @calendars["#{calendar_id}"]["background_color"]
           events = JSON.parse(@data_store.load(key))
           events["items"].each do |event|
-            collection << GoogleCalendar::Event.new(event,color).to_fullcalendar
+            collection << GoogleCalendar::Event.new(event,color,calendar_id).to_fullcalendar
           end
         end
       end

--- a/app/models/google_calendar/event.rb
+++ b/app/models/google_calendar/event.rb
@@ -1,8 +1,9 @@
 module GoogleCalendar
   class Event
-    def initialize(event,color)
+    def initialize(event,color,calendar_id)
       @event = event
       @color = color
+      @calendar_id = calendar_id
     end
 
     def to_fullcalendar
@@ -17,6 +18,7 @@ module GoogleCalendar
       else
         full_event["allDay"] = false
       end
+      full_event["className"] = @calendar_id
       return full_event
     end# method to_fullcalendar
   end# class Event

--- a/app/views/events/_calendar_list.html.erb
+++ b/app/views/events/_calendar_list.html.erb
@@ -1,11 +1,9 @@
 <div id="external-calendars">
   <% calendars["items"].each do |c| %>
   <div>
-  <font color=<%= c["background_color"] %>>■</font><%= c["summary"] %>
+	<input type="checkbox" value=<%= c["id"]%> class="event_view_switch" checked><font color=<%= c["background_color"] %>><%= c["summary"] %></font>
   </div>
   <% end %>
-  <input type="checkbox" id="cbox1" value="first_checkbox" checked><font color=#16a765> calendar1</font><br>
-  <input type="checkbox" id="cbox2" value="second_checkbox" checked> calendar2
 <div align="right">
   <%= link_to "他のカレンダーをインポート",
       :controller => "calendars",


### PR DESCRIPTION
#47 に対するPRである．

### 今回やったこと
+ サイドメニューにチェックボックスを追加し，チェックボックスをクリックすることで，カレンダごとに予定の表示/非表示を切り替えられる機能を追加した．
+ 予定の`className`には，redisに保存されているキーから取得したカレンダidを与えている．チェックボックスでは，この`className`を指定することで予定の表示/非表示を切り替えている．
+ カレンダidには`@`や`.`のような特殊文字が存在する．このため，特殊文字をエスケープする`selectorEscape`を作成した．