### PR TITLE
 Use docker-compose for run and development 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+./config/application_settings.yml
+./config/database.yml
+./config/environments/deveropment.rb
+
+vender/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ bower.json
 attic/
 
 config/environments/development.rb
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ pickle-email-*.html
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
 config/setting_google_calendar.yml
 config/application_settings.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM ruby:2.1.5
 RUN apt-get update -qq && apt-get install -y build-essential ruby-dev libxslt1-dev libxml2-dev libpq-dev nodejs sqlite3 postgresql-client redis-server
 
-RUN git clone https://github.com/nomlab/camome.git
-
 WORKDIR camome
 
-ADD Gemfile Gemfile
+COPY Gemfile Gemfile.lock /camome/
 RUN bundle install --path vendor/bundle
-ADD config/secrets.yml config/secrets.yml
-ADD config/application_settings.yml config/application_settings.yml
-ADD config/database.yml config/database.yml
-ADD config/environments/development.rb config/environments/development.rb
+
+COPY . /camome
+
 RUN git submodule init
 RUN git config submodule.vendor/assets/bootstrap-table.url https://github.com/wenzhixin/bootstrap-table.git
 RUN git config submodule.vendor/assets/jsSHA.url https://github.com/Caligatio/jsSHA.git
-RUN git submodule update 
+RUN git submodule update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.1.5
+RUN apt-get update -qq && apt-get install -y build-essential ruby-dev libxslt1-dev libxml2-dev libpq-dev nodejs sqlite3 postgresql-client redis-server
+
+RUN git clone https://github.com/nomlab/camome.git
+
+WORKDIR camome
+
+RUN bundle install --path vendor/bundle
+ADD config/secrets.yml config/secrets.yml
+ADD config/application_settings.yml config/application_settings.yml
+ADD config/database.yml config/database.yml
+RUN git submodule init
+RUN git config submodule.vendor/assets/bootstrap-table.url https://github.com/wenzhixin/bootstrap-table.git
+RUN git config submodule.vendor/assets/jsSHA.url https://github.com/Caligatio/jsSHA.git
+RUN git submodule update 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ RUN git clone https://github.com/nomlab/camome.git
 
 WORKDIR camome
 
+ADD Gemfile Gemfile
 RUN bundle install --path vendor/bundle
 ADD config/secrets.yml config/secrets.yml
 ADD config/application_settings.yml config/application_settings.yml
 ADD config/database.yml config/database.yml
+ADD config/environments/development.rb config/environments/development.rb
 RUN git submodule init
 RUN git config submodule.vendor/assets/bootstrap-table.url https://github.com/wenzhixin/bootstrap-table.git
 RUN git config submodule.vendor/assets/jsSHA.url https://github.com/Caligatio/jsSHA.git

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.1.8'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
+gem 'pg'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.3'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.1.8'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
-gem 'pg'
+gem 'pg', '~> 0.20.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.3'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     less-rails (2.6.0)
       actionpack (>= 3.1)
       less (~> 2.6.0)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.19)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
@@ -123,6 +123,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
+    pg (0.21.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -232,6 +233,7 @@ DEPENDENCIES
   nokogiri
   omniauth
   omniauth-google-oauth2
+  pg
   rails (= 4.1.8)
   redis
   rspec-rails

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -174,7 +174,7 @@ class EventsController < ApplicationController
   def exist_token?
     ds = DataStore::RedisStore.new
     user = current_user
-    if ds.load(user.auth_name) == nil && user.master_auth_info.token != nil
+    if ds.load(user.auth_name) == nil
       redirect_to :action => "input_master_pass"
     end
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -35,7 +35,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     case state
     when "invitation"
-      user = User.where("invitation_token is ?", token).first
+      user = User.where("invitation_token = token").first
       if user
         User.current = user
         user.provider = auth.provider

--- a/app/models/redis_store.rb
+++ b/app/models/redis_store.rb
@@ -1,7 +1,9 @@
+require 'uri'
 module DataStore
   class RedisStore < Base
     def initialize
-      @redis = Redis.new
+      uri = URI.parse(ApplicationSettings.redis.url)
+      @redis = Redis.new(host: uri.host, port: uri.port)
     end
 
     def load(key)

--- a/config/application_settings_sample.yml
+++ b/config/application_settings_sample.yml
@@ -7,6 +7,8 @@ default: &default
     google:
       application_id: XXXXXXXXXXXXXXXXX
       application_secret: XXXXXXXXXXXXXXXXX
+  redis:
+    url: redis://XXXXX:6379
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,15 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  timeout: 5000
 
-development:
+development: &development
   <<: *default
-  database: db/development.sqlite3
+  database: camome_development
+  username: postgres
+  password:
+  host: db
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  database: camome_test

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,6 @@
+development:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+test:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,38 @@
-version: '2'
+version: '3'
 services:    
   db:
     container_name: db
     image: postgres
     expose:
       - "5432"
+    volumes:
+      - ./db/camome_pgdata:/var/lib/postgresql/data
       
   web:
-    container_name: camome
     build: .
+    container_name: camome
+    image: nomlab/camome
     command: bundle exec rails s -p 3000 -b 0.0.0.0
     ports:
       - "3000:3000"
-    links:
+    depends_on:
       - redis
       - db
-
+    volumes:
+      - ./config/application_settings.yml:/camome/config/application_settings.yml
+      - ./config/database.yml:/camome/config/database.yml
+      - ./config/environments/deveropment.rb:/camome/config/environments/deveropment.rb
+    env_file: .env
+    
   redis:
     container_name: redis
     image: redis
-    expose:
-      - "6379"
+
+  goohub:
+    container_name: goohub
+    image: nomlab/goohub
+    links:
+      - redis
+      - web
     volumes:
-      - ./redis:/data
-    command: redis-server --appendonly yes
+      - ./goohub:/root/.config/goohub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  db:
+    container_name: db
+    image: postgres
+    expose:
+      - "5432"
+      
+  web:
+    container_name: camome
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    ports:
+      - "3000:3000"
+    links:
+      - redis
+      - db
+
+  redis:
+    container_name: redis
+    image: redis
+    expose:
+      - "6379"
+    volumes:
+      - ./redis:/data
+    command: redis-server --appendonly yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2'
-services:
+services:    
   db:
     container_name: db
     image: postgres
@@ -9,7 +9,7 @@ services:
   web:
     container_name: camome
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bundle exec rails s -p 3000 -b 0.0.0.0
     ports:
       - "3000:3000"
     links:


### PR DESCRIPTION
#54 に対する PR である．

docker-compose を使用して redis，goohub，camome，および camome のデータベースをそれぞれ別コンテナとして立ち上げ実行できるようにした．
camome のイメージは Dockerfile から作成している．また，goohub のイメージは DockerHub の nomlab/goohub を用いた．

camome のイメージ作成から起動までの手順を以下に示す．

1. camome のイメージを Dockerfile から作成
```
$ docker-compose build
```
2. シークレットキーの設定
```
$ docker-compose run --rm web bundle exec rake secret
```
Rails のルートに `.env` というファイルを作成し，上のコマンドで発行されたシークレットキーを以下のように書き込み保存する．
```
SECRET_KEY_BASE=XXXXXXXXXXXXXXXXXXXXXXXXXXX
```
3. データベースの設定
```
$ docker-compose run --rm web bundle exec rake db:create db:migrate db:seed
```
4. camome の起動
```
docker-compose up web
```

また，以下に起動時にマウントされる設定ファイルを示す．
  + config/database.yml
  + config/application_settings.yml
  + config/environments/deveropment.rb

goohub から redis に予定をを送信するには，以下のコマンドを実行する．
```
$ docker-compose run --rm goohub events <CALENDAR_ID> <YYYY-MM> --output=redis:redis
```
設定についての詳細は https://github.com/nomlab/goohub/pull/20 を参照．